### PR TITLE
Implement binary support for ios as well

### DIFF
--- a/src/android/Connection.java
+++ b/src/android/Connection.java
@@ -12,148 +12,147 @@ import java.net.UnknownHostException;
 /**
  * @author viniciusl
  *
- * This class represents a socket connection, behaving like a thread to listen 
+ * This class represents a socket connection, behaving like a thread to listen
  * a TCP port and receive data
  */
 public class Connection extends Thread {
-	private SocketPlugin hook;
+    private SocketPlugin hook;
 
-	private Socket callbackSocket;
-	private PrintWriter writer;
-	private OutputStream outputStream;
-	private BufferedReader reader;
+    private Socket callbackSocket;
+    private PrintWriter writer;
+    private OutputStream outputStream;
+    private BufferedReader reader;
 
-	private Boolean mustClose;
-	private String host;
-	private int port;
-
-
-	/**
-	 * Creates a TCP socket connection object.
-	 * 
-	 * @param pool Object containing "sendMessage" method to be called as a callback for data receive.
-	 * @param host Target host for socket connection.
-	 * @param port Target port for socket connection
-	 */
-	public Connection(SocketPlugin pool, String host, int port) {
-		super();
-		setDaemon(true);
-
-		this.mustClose = false;
-		this.host = host;
-		this.port = port;
-		this.hook = pool;
-	}
+    private Boolean mustClose;
+    private String host;
+    private int port;
 
 
-	/**
-	 * Returns socket connection state.
-	 * 
-	 * @return true if socket connection is established or false case else.
-	 */
-	public boolean isConnected() {
+    /**
+     * Creates a TCP socket connection object.
+     *
+     * @param pool Object containing "sendMessage" method to be called as a callback for data receive.
+     * @param host Target host for socket connection.
+     * @param port Target port for socket connection
+     */
+    public Connection(SocketPlugin pool, String host, int port) {
+        super();
+        setDaemon(true);
 
-		boolean result =  (
-				this.callbackSocket == null ? false : 
-					this.callbackSocket.isConnected() && 
-					this.callbackSocket.isBound() && 
-					!this.callbackSocket.isClosed() && 
-					!this.callbackSocket.isInputShutdown() && 
-					!this.callbackSocket.isOutputShutdown());
-
-		// if everything apparently is fine, time to test the streams
-		if (result) {
-			try {
-				this.callbackSocket.getInputStream().available();
-			} catch (IOException e) {
-				// connection lost
-				result = false;
-			}
-		}
-
-		return result;
-	}
-
-	/**
-	 * Closes socket connection. 
-	 */
-	public void close() {
-		// closing connection
-		try {
-			//this.writer.close();
-			//this.reader.close();
-			callbackSocket.shutdownInput();
-			callbackSocket.shutdownOutput();
-			callbackSocket.close();
-			this.mustClose = true;
-		} catch (IOException e) {
-			e.printStackTrace();
-		}		
-	}
+        this.mustClose = false;
+        this.host = host;
+        this.port = port;
+        this.hook = pool;
+    }
 
 
-	/**
-	 * Writes on socket output stream to send data to target host.
-	 * 
-	 * @param data information to be sent
-	 */
-	public void write(String data) {
-		this.writer.println(data);
-	}
+    /**
+     * Returns socket connection state.
+     *
+     * @return true if socket connection is established or false case else.
+     */
+    public boolean isConnected() {
+
+        boolean result =  (
+                this.callbackSocket == null ? false :
+                    this.callbackSocket.isConnected() &&
+                    this.callbackSocket.isBound() &&
+                    !this.callbackSocket.isClosed() &&
+                    !this.callbackSocket.isInputShutdown() &&
+                    !this.callbackSocket.isOutputShutdown());
+
+        // if everything apparently is fine, time to test the streams
+        if (result) {
+            try {
+                this.callbackSocket.getInputStream().available();
+            } catch (IOException e) {
+                // connection lost
+                result = false;
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Closes socket connection.
+     */
+    public void close() {
+        // closing connection
+        try {
+            //this.writer.close();
+            //this.reader.close();
+            callbackSocket.shutdownInput();
+            callbackSocket.shutdownOutput();
+            callbackSocket.close();
+            this.mustClose = true;
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 
 
-
-	/**
-	 * Outputs to socket output stream to send binary data to target host.
-	 * 
-	 * @param data information to be sent
-	 */
-	public void writeBinary(byte[] data) throws IOException {
-		this.outputStream.write(data);
-	}
+    /**
+     * Writes on socket output stream to send data to target host.
+     *
+     * @param data information to be sent
+     */
+    public void write(String data) {
+        this.writer.println(data);
+    }
 
 
 
-	/* (non-Javadoc)
-	 * @see java.lang.Thread#run()
-	 */
-	public void run() {
+    /**
+     * Outputs to socket output stream to send binary data to target host.
+     *
+     * @param data information to be sent
+     */
+    public void writeBinary(byte[] data) throws IOException {
+        this.outputStream.write(data);
+    }
+
+
+    /* (non-Javadoc)
+     * @see java.lang.Thread#run()
+     */
+    public void run() {
     byte[] chunk = new byte[512];
 
-		// creating connection
-		try {
-			this.callbackSocket = new Socket(this.host, this.port);
-			this.writer = new PrintWriter(this.callbackSocket.getOutputStream(), true);
-			this.outputStream = this.callbackSocket.getOutputStream();
-			this.reader = new BufferedReader(new InputStreamReader(callbackSocket.getInputStream()));
+        // creating connection
+        try {
+            this.callbackSocket = new Socket(this.host, this.port);
+            this.writer = new PrintWriter(this.callbackSocket.getOutputStream(), true);
+            this.outputStream = this.callbackSocket.getOutputStream();
+            this.reader = new BufferedReader(new InputStreamReader(callbackSocket.getInputStream()));
 
-			// receiving data chunk
-			while(!this.mustClose){
+            // receiving data chunk
+            while(!this.mustClose){
 
-				try {
+                try {
 
-					if (this.isConnected()) {
-            int bytesRead = callbackSocket.getInputStream().read(chunk);
-            byte[] line = new byte[bytesRead];
-            System.arraycopy(chunk, 0, line, 0, bytesRead);
+                    if (this.isConnected()) {
+                        int bytesRead = callbackSocket.getInputStream().read(chunk);
+                        byte[] line = new byte[bytesRead];
+                        System.arraycopy(chunk, 0, line, 0, bytesRead);
 
-						if (bytesRead > 0) {
-							hook.sendMessage(this.host, this.port, line);
-						}
-					}
-				} catch (Exception e) {
-					e.printStackTrace();
-				}
-			}
+                        if (bytesRead > 0) {
+                            hook.sendMessage(this.host, this.port, line);
+                        }
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
 
-		} catch (UnknownHostException e1) {
-			// TODO Auto-generated catch block
-			e1.printStackTrace();
-		} catch (IOException e1) {
-			// TODO Auto-generated catch block
-			e1.printStackTrace();
-		}
+        } catch (UnknownHostException e1) {
+            // TODO Auto-generated catch block
+            e1.printStackTrace();
+        } catch (IOException e1) {
+            // TODO Auto-generated catch block
+            e1.printStackTrace();
+        }
 
-	}
+    }
 
 }

--- a/src/android/Connection.java
+++ b/src/android/Connection.java
@@ -118,7 +118,7 @@ public class Connection extends Thread {
 	 * @see java.lang.Thread#run()
 	 */
 	public void run() {
-		String chunk = null;
+    byte[] chunk = new byte[512];
 
 		// creating connection
 		try {
@@ -133,12 +133,12 @@ public class Connection extends Thread {
 				try {
 
 					if (this.isConnected()) {
-						chunk = reader.readLine();
+            int bytesRead = callbackSocket.getInputStream().read(chunk);
+            byte[] line = new byte[bytesRead];
+            System.arraycopy(chunk, 0, line, 0, bytesRead);
 
-						if (chunk != null) {
-							chunk = chunk.replaceAll("\"\"", "null");
-							System.out.print("## RECEIVED DATA: " + chunk);
-							hook.sendMessage(this.host, this.port, chunk);
+						if (bytesRead > 0) {
+							hook.sendMessage(this.host, this.port, line);
 						}
 					}
 				} catch (Exception e) {

--- a/src/android/SocketPlugin.java
+++ b/src/android/SocketPlugin.java
@@ -19,7 +19,7 @@ import org.json.JSONException;
 /**
  * @author viniciusl
  *
- * Plugin to handle TCP socket connections.	
+ * Plugin to handle TCP socket connections.
  */
 /**
  * @author viniciusl
@@ -27,323 +27,323 @@ import org.json.JSONException;
  */
 public class SocketPlugin extends CordovaPlugin {
 
-	private Map<String, Connection> pool = new HashMap<String,Connection>();		// pool of "active" connections
+    private Map<String, Connection> pool = new HashMap<String,Connection>();        // pool of "active" connections
 
-	/* (non-Javadoc)
-	 * @see org.apache.cordova.CordovaPlugin#execute(java.lang.String, org.json.JSONArray, org.apache.cordova.CallbackContext)
-	 */
-	@Override
-	public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
+    /* (non-Javadoc)
+     * @see org.apache.cordova.CordovaPlugin#execute(java.lang.String, org.json.JSONArray, org.apache.cordova.CallbackContext)
+     */
+    @Override
+    public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
 
-		if (action.equals("connect")) {
-			this.connect(args, callbackContext);
-			return true;
+        if (action.equals("connect")) {
+            this.connect(args, callbackContext);
+            return true;
 
-		}else if(action.equals("isConnected")) {
-			this.isConnected(args, callbackContext);
-			return true;
-			
-		}else if(action.equals("send")) {
-			this.send(args, callbackContext);
-			return true;
+        }else if(action.equals("isConnected")) {
+            this.isConnected(args, callbackContext);
+            return true;
 
-		}else if(action.equals("sendBinary")) {
-			this.sendBinary(args, callbackContext);
-			return true;
+        }else if(action.equals("send")) {
+            this.send(args, callbackContext);
+            return true;
 
-		} else if (action.equals("disconnect")) {
-			this.disconnect(args, callbackContext);
-			return true;
+        }else if(action.equals("sendBinary")) {
+            this.sendBinary(args, callbackContext);
+            return true;
 
-		} else if (action.equals("disconnectAll")) {
-			this.disconnectAll(callbackContext);
-			return true;
+        } else if (action.equals("disconnect")) {
+            this.disconnect(args, callbackContext);
+            return true;
 
-		}  else {
-			return false;
-		}
-	}
+        } else if (action.equals("disconnectAll")) {
+            this.disconnectAll(callbackContext);
+            return true;
 
-	/**
-	 * Build a key to identify a socket connection based on host and port information.
-	 * 
-	 * @param host Target host
-	 * @param port Target port
-	 * @return connection key
-	 */
-	@SuppressLint("DefaultLocale")
-	private String buildKey(String host, int port) {
-		return (host.toLowerCase() + ":" + port);
-	}
+        }  else {
+            return false;
+        }
+    }
 
-	/**
-	 * Opens a socket connection.
-	 * 
-	 * @param args
-	 * @param callbackContext
-	 */
-	private void connect (JSONArray args, CallbackContext callbackContext) {
-		String key;
-		String host;
-		int port;
-		Connection socket;
+    /**
+     * Build a key to identify a socket connection based on host and port information.
+     *
+     * @param host Target host
+     * @param port Target port
+     * @return connection key
+     */
+    @SuppressLint("DefaultLocale")
+    private String buildKey(String host, int port) {
+        return (host.toLowerCase() + ":" + port);
+    }
 
-		// validating parameters
-		if (args.length() < 2) {
-			callbackContext.error("Missing arguments when calling 'connect' action.");
-		} else {
+    /**
+     * Opens a socket connection.
+     *
+     * @param args
+     * @param callbackContext
+     */
+    private void connect (JSONArray args, CallbackContext callbackContext) {
+        String key;
+        String host;
+        int port;
+        Connection socket;
 
-			// opening connection and adding into pool
-			try {
+        // validating parameters
+        if (args.length() < 2) {
+            callbackContext.error("Missing arguments when calling 'connect' action.");
+        } else {
 
-				// preparing parameters
-				host = args.getString(0);
-				port = args.getInt(1);
-				key = this.buildKey(host, port);
+            // opening connection and adding into pool
+            try {
 
-				// creating connection
-				if (this.pool.get(key) == null) {
-					socket = new Connection(this, host, port);
-					socket.start();
-					this.pool.put(key, socket);
-				}
+                // preparing parameters
+                host = args.getString(0);
+                port = args.getInt(1);
+                key = this.buildKey(host, port);
 
-				// adding to pool
-				callbackContext.success(key);
+                // creating connection
+                if (this.pool.get(key) == null) {
+                    socket = new Connection(this, host, port);
+                    socket.start();
+                    this.pool.put(key, socket);
+                }
 
-			} catch (JSONException e) {
-				callbackContext.error("Invalid parameters for 'connect' action: " + e.getMessage());
-			}
-		}
-	}
-	
-	/**
-	 * Returns connection information
-	 * 
-	 * @param args
-	 * @param callbackContext
-	 */
-	private void isConnected(JSONArray args, CallbackContext callbackContext) {
-		Connection socket;
-		
-		// validating parameters
-		if (args.length() < 1) {
-			callbackContext.error("Missing arguments when calling 'isConnected' action.");
-		} else {
-			try {
-				// retrieving parameters
-				String key = args.getString(0);
-				
-				// getting socket
-				socket = this.pool.get(key);
-				
-				// checking if socket was not found and his connectivity
-				if (socket == null) {
-					callbackContext.error("No connection found with host " + key);
-				
-				} else {
-					
-					// ending send process
-					callbackContext.success( (socket.isConnected() ? 1 : 0) );	
-				}
-								
-			} catch (JSONException e) {
-				callbackContext.error("Unexpected error sending information: " + e.getMessage());
-			}
-		}
-	}
-	
+                // adding to pool
+                callbackContext.success(key);
 
-	/**
-	 * Send information to target host
-	 * 
-	 * @param args
-	 * @param callbackContext
-	 */
-	private void send(JSONArray args, CallbackContext callbackContext) {
-		Connection socket;
-		
-		// validating parameters
-		if (args.length() < 2) {
-			callbackContext.error("Missing arguments when calling 'send' action.");
-		} else {
-			try {
-				// retrieving parameters
-				String key = args.getString(0);
-				String data = args.getString(1);
-				
-				// getting socket
-				socket = this.pool.get(key);
-				
-				// checking if socket was not found and his connectivity
-				if (socket == null) {
-					callbackContext.error("No connection found with host " + key);
-				
-				} else if (!socket.isConnected()) {
-					callbackContext.error("Invalid connection with host " + key);
-				
-				} else if (data.length() == 0) {
-					callbackContext.error("Cannot send empty data to " + key);
-				
-				} else {
-				
-					// write on output stream
-					socket.write(data);
-					
-					// ending send process
-					callbackContext.success();	
-				}
-								
-			} catch (JSONException e) {
-				callbackContext.error("Unexpected error sending information: " + e.getMessage());
-			}
-		}
-	}
+            } catch (JSONException e) {
+                callbackContext.error("Invalid parameters for 'connect' action: " + e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Returns connection information
+     *
+     * @param args
+     * @param callbackContext
+     */
+    private void isConnected(JSONArray args, CallbackContext callbackContext) {
+        Connection socket;
+
+        // validating parameters
+        if (args.length() < 1) {
+            callbackContext.error("Missing arguments when calling 'isConnected' action.");
+        } else {
+            try {
+                // retrieving parameters
+                String key = args.getString(0);
+
+                // getting socket
+                socket = this.pool.get(key);
+
+                // checking if socket was not found and his connectivity
+                if (socket == null) {
+                    callbackContext.error("No connection found with host " + key);
+
+                } else {
+
+                    // ending send process
+                    callbackContext.success( (socket.isConnected() ? 1 : 0) );
+                }
+
+            } catch (JSONException e) {
+                callbackContext.error("Unexpected error sending information: " + e.getMessage());
+            }
+        }
+    }
 
 
-	/**
-	 * Send binary information to target host
-	 * 
-	 * @param args
-	 * @param callbackContext
-	 */
-	private void sendBinary(JSONArray args, CallbackContext callbackContext) {
-		Connection socket;
-		
-		// validating parameters
-		if (args.length() < 2) {
-			callbackContext.error("Missing arguments when calling 'sendBinary' action.");
-		} else {
-			try {
-				// retrieving parameters
-				String key = args.getString(0);
-				JSONArray jsData = args.getJSONArray(1);
-				byte[] data = new byte[jsData.length()];
-				for (int i=0; i<jsData.length(); i++)
-					data[i]=(byte)jsData.getInt(i);
-				
-				// getting socket
-				socket = this.pool.get(key);
-				
-				// checking if socket was not found and his connectivity
-				if (socket == null) {
-					callbackContext.error("No connection found with host " + key);
-				
-				} else if (!socket.isConnected()) {
-					callbackContext.error("Invalid connection with host " + key);
-				
-				} else if (data.length == 0) {
-					callbackContext.error("Cannot send empty data to " + key);
-				
-				} else {
-				
-					try {
-						// write on output stream
-						socket.writeBinary(data);
-					
-						// ending send process
-						callbackContext.success();	
+    /**
+     * Send information to target host
+     *
+     * @param args
+     * @param callbackContext
+     */
+    private void send(JSONArray args, CallbackContext callbackContext) {
+        Connection socket;
 
-					} catch (IOException e) {
-						callbackContext.error("I/O error sending to " + key);
-					}
-				}
-								
-			} catch (JSONException e) {
-				callbackContext.error("Unexpected error sending information: " + e.getMessage());
-			}
-		}
-	}
+        // validating parameters
+        if (args.length() < 2) {
+            callbackContext.error("Missing arguments when calling 'send' action.");
+        } else {
+            try {
+                // retrieving parameters
+                String key = args.getString(0);
+                String data = args.getString(1);
 
-	/**
-	 * Closes an existing connection
-	 * 
-	 * @param args
-	 * @param callbackContext
-	 */
-	private void disconnect (JSONArray args, CallbackContext callbackContext) {
-		String key;
-		Connection socket;
+                // getting socket
+                socket = this.pool.get(key);
 
-		// validating parameters
-		if (args.length() < 1) {
-			callbackContext.error("Missing arguments when calling 'disconnect' action.");
-		} else {
+                // checking if socket was not found and his connectivity
+                if (socket == null) {
+                    callbackContext.error("No connection found with host " + key);
 
-			try {
-				// preparing parameters
-				key = args.getString(0);
+                } else if (!socket.isConnected()) {
+                    callbackContext.error("Invalid connection with host " + key);
 
-				// getting connection from pool
-				socket = pool.get(key);
+                } else if (data.length() == 0) {
+                    callbackContext.error("Cannot send empty data to " + key);
 
-				// closing socket
-				if (socket != null) {
-					
-					// checking connection
-					if (socket.isConnected()) {
-						socket.close();
-					}
-					
-					// removing from pool
-					pool.remove(key);
-				}
+                } else {
 
-				// ending with success
-				callbackContext.success("Disconnected from " + key);
+                    // write on output stream
+                    socket.write(data);
 
-			} catch (JSONException e) {
-				callbackContext.error("Invalid parameters for 'connect' action:" + e.getMessage());
-			}
-		}
-	}
+                    // ending send process
+                    callbackContext.success();
+                }
 
-	/**
-	 * Closes all existing connections
-	 *
-	 * @param callbackContext
-	 */
-	private void disconnectAll (CallbackContext callbackContext) {
-		// building iterator
-		Iterator<Entry<String, Connection>> it = this.pool.entrySet().iterator();
-
-		while( it.hasNext() ) {
-
-			// retrieving object
-			Map.Entry<String, Connection> pairs = (Entry<String, Connection>) it.next();
-			Connection socket = pairs.getValue();
-
-			// checking connection
-			if (socket.isConnected()) {
-				socket.close();
-			}
-
-			// removing from pool
-			this.pool.remove(pairs.getKey());
-		}
-
-		callbackContext.success("All connections were closed.");
-	}
+            } catch (JSONException e) {
+                callbackContext.error("Unexpected error sending information: " + e.getMessage());
+            }
+        }
+    }
 
 
-	/**
-	 * Callback for Connection object data receive. Relay information to javascript object method: window.tlantic.plugins.socket.receive();
-	 *
-	 * @param host
-	 * @param port
-	 * @param chunk
-	 */
-	public synchronized void sendMessage(String host, int port, byte[] chunk) {
-		final String receiveHook = "window.tlantic.plugins.socket.receive(\"" + host + "\"," + port + ",\"" + this.buildKey(host, port) + "\",\"" + Base64.encodeToString(chunk, Base64.DEFAULT) + "\");";
+    /**
+     * Send binary information to target host
+     *
+     * @param args
+     * @param callbackContext
+     */
+    private void sendBinary(JSONArray args, CallbackContext callbackContext) {
+        Connection socket;
 
-		cordova.getActivity().runOnUiThread(new Runnable() {
+        // validating parameters
+        if (args.length() < 2) {
+            callbackContext.error("Missing arguments when calling 'sendBinary' action.");
+        } else {
+            try {
+                // retrieving parameters
+                String key = args.getString(0);
+                JSONArray jsData = args.getJSONArray(1);
+                byte[] data = new byte[jsData.length()];
+                for (int i=0; i<jsData.length(); i++)
+                    data[i]=(byte)jsData.getInt(i);
 
-			@Override
-			public void run() {
-				webView.loadUrl("javascript:" + receiveHook);
-			}
+                // getting socket
+                socket = this.pool.get(key);
 
-		});
-	}
+                // checking if socket was not found and his connectivity
+                if (socket == null) {
+                    callbackContext.error("No connection found with host " + key);
+
+                } else if (!socket.isConnected()) {
+                    callbackContext.error("Invalid connection with host " + key);
+
+                } else if (data.length == 0) {
+                    callbackContext.error("Cannot send empty data to " + key);
+
+                } else {
+
+                    try {
+                        // write on output stream
+                        socket.writeBinary(data);
+
+                        // ending send process
+                        callbackContext.success();
+
+                    } catch (IOException e) {
+                        callbackContext.error("I/O error sending to " + key);
+                    }
+                }
+
+            } catch (JSONException e) {
+                callbackContext.error("Unexpected error sending information: " + e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Closes an existing connection
+     *
+     * @param args
+     * @param callbackContext
+     */
+    private void disconnect (JSONArray args, CallbackContext callbackContext) {
+        String key;
+        Connection socket;
+
+        // validating parameters
+        if (args.length() < 1) {
+            callbackContext.error("Missing arguments when calling 'disconnect' action.");
+        } else {
+
+            try {
+                // preparing parameters
+                key = args.getString(0);
+
+                // getting connection from pool
+                socket = pool.get(key);
+
+                // closing socket
+                if (socket != null) {
+
+                    // checking connection
+                    if (socket.isConnected()) {
+                        socket.close();
+                    }
+
+                    // removing from pool
+                    pool.remove(key);
+                }
+
+                // ending with success
+                callbackContext.success("Disconnected from " + key);
+
+            } catch (JSONException e) {
+                callbackContext.error("Invalid parameters for 'connect' action:" + e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Closes all existing connections
+     *
+     * @param callbackContext
+     */
+    private void disconnectAll (CallbackContext callbackContext) {
+        // building iterator
+        Iterator<Entry<String, Connection>> it = this.pool.entrySet().iterator();
+
+        while( it.hasNext() ) {
+
+            // retrieving object
+            Map.Entry<String, Connection> pairs = (Entry<String, Connection>) it.next();
+            Connection socket = pairs.getValue();
+
+            // checking connection
+            if (socket.isConnected()) {
+                socket.close();
+            }
+
+            // removing from pool
+            this.pool.remove(pairs.getKey());
+        }
+
+        callbackContext.success("All connections were closed.");
+    }
+
+
+    /**
+     * Callback for Connection object data receive. Relay information to javascript object method: window.tlantic.plugins.socket.receive();
+     *
+     * @param host
+     * @param port
+     * @param chunk
+     */
+    public synchronized void sendMessage(String host, int port, byte[] chunk) {
+        final String receiveHook = "window.tlantic.plugins.socket.receive(\"" + host + "\"," + port + ",\"" + this.buildKey(host, port) + "\",window.atob(\"" + Base64.encodeToString(chunk, Base64.DEFAULT) + ")\");";
+
+        cordova.getActivity().runOnUiThread(new Runnable() {
+
+            @Override
+            public void run() {
+                webView.loadUrl("javascript:" + receiveHook);
+            }
+
+        });
+    }
 
 }

--- a/src/android/SocketPlugin.java
+++ b/src/android/SocketPlugin.java
@@ -334,7 +334,7 @@ public class SocketPlugin extends CordovaPlugin {
      * @param chunk
      */
     public synchronized void sendMessage(String host, int port, byte[] chunk) {
-        final String receiveHook = "window.tlantic.plugins.socket.receive(\"" + host + "\"," + port + ",\"" + this.buildKey(host, port) + "\",window.atob(\"" + Base64.encodeToString(chunk, Base64.DEFAULT) + ")\");";
+        final String receiveHook = "window.tlantic.plugins.socket.receive(\"" + host + "\"," + port + ",\"" + this.buildKey(host, port) + "\",window.atob(\"" + Base64.encodeToString(chunk, Base64.DEFAULT) + "\"));";
 
         cordova.getActivity().runOnUiThread(new Runnable() {
 

--- a/src/android/SocketPlugin.java
+++ b/src/android/SocketPlugin.java
@@ -334,7 +334,7 @@ public class SocketPlugin extends CordovaPlugin {
 	 * @param chunk
 	 */
 	public synchronized void sendMessage(String host, int port, byte[] chunk) {
-		final String receiveHook = "window.tlantic.plugins.socket.receive(\"" + host + "\"," + port + ",\"" + this.buildKey(host, port) + "\",\"" + Base64.encodeToString(chunk, Base64.URL_SAFE) + "\");";
+		final String receiveHook = "window.tlantic.plugins.socket.receive(\"" + host + "\"," + port + ",\"" + this.buildKey(host, port) + "\",\"" + Base64.encodeToString(chunk, Base64.DEFAULT) + "\");";
 
 		cordova.getActivity().runOnUiThread(new Runnable() {
 

--- a/src/android/SocketPlugin.java
+++ b/src/android/SocketPlugin.java
@@ -2,6 +2,8 @@ package com.tlantic.plugins.socket;
 
 import android.annotation.SuppressLint;
 
+import android.util.Base64;
+
 import java.io.IOException;
 
 import java.util.HashMap;
@@ -293,55 +295,55 @@ public class SocketPlugin extends CordovaPlugin {
 			} catch (JSONException e) {
 				callbackContext.error("Invalid parameters for 'connect' action:" + e.getMessage());
 			}
-		}		
+		}
 	}
 
 	/**
 	 * Closes all existing connections
-	 * 
+	 *
 	 * @param callbackContext
 	 */
 	private void disconnectAll (CallbackContext callbackContext) {
 		// building iterator
 		Iterator<Entry<String, Connection>> it = this.pool.entrySet().iterator();
-		
+
 		while( it.hasNext() ) {
-			
+
 			// retrieving object
 			Map.Entry<String, Connection> pairs = (Entry<String, Connection>) it.next();
 			Connection socket = pairs.getValue();
-			
+
 			// checking connection
 			if (socket.isConnected()) {
 				socket.close();
 			}
-			
+
 			// removing from pool
 			this.pool.remove(pairs.getKey());
 		}
-		
+
 		callbackContext.success("All connections were closed.");
 	}
 
 
 	/**
 	 * Callback for Connection object data receive. Relay information to javascript object method: window.tlantic.plugins.socket.receive();
-	 * 
+	 *
 	 * @param host
 	 * @param port
 	 * @param chunk
 	 */
-	public synchronized void sendMessage(String host, int port, String chunk) {
-		final String receiveHook = "window.tlantic.plugins.socket.receive(\"" + host + "\"," + port + ",\"" + this.buildKey(host, port) + "\",\"" + chunk.replace("\"", "\\\"") + "\");";
-		
+	public synchronized void sendMessage(String host, int port, byte[] chunk) {
+		final String receiveHook = "window.tlantic.plugins.socket.receive(\"" + host + "\"," + port + ",\"" + this.buildKey(host, port) + "\",\"" + Base64.encodeToString(chunk, Base64.URL_SAFE) + "\");";
+
 		cordova.getActivity().runOnUiThread(new Runnable() {
 
 			@Override
 			public void run() {
 				webView.loadUrl("javascript:" + receiveHook);
 			}
-			
+
 		});
 	}
-	
+
 }

--- a/src/ios/CDVSocketPlugin.h
+++ b/src/ios/CDVSocketPlugin.h
@@ -10,6 +10,7 @@
 -(void) disconnectAll: (CDVInvokedUrlCommand *) command;
 -(void) isConnected: (CDVInvokedUrlCommand *) command;
 -(void) send: (CDVInvokedUrlCommand *) command;
+-(void) sendBinary: (CDVInvokedUrlCommand *) command;
 
 -(BOOL) disposeConnection :(NSString *)key;
 

--- a/src/ios/CDVSocketPlugin.m
+++ b/src/ios/CDVSocketPlugin.m
@@ -7,19 +7,19 @@
 - (NSString*) buildKey : (NSString*) host : (int) port {
     NSString* tempHost = [host lowercaseString];
     NSString* tempPort = [NSString stringWithFormat : @"%d", port];
-    
+
     return  [[tempHost stringByAppendingString : @":"] stringByAppendingString:tempPort];
 }
 
 - (void) connect : (CDVInvokedUrlCommand*) command {
     // Validating parameters
     if ([command.arguments count] < 2) {
-        
+
         // Triggering parameter error
         CDVPluginResult* result = [CDVPluginResult
                                    resultWithStatus : CDVCommandStatus_ERROR
                                    messageAsString  : @"Missing arguments when calling 'connect' action."];
-        
+
         [self.commandDelegate
             sendPluginResult : result
             callbackId : command.callbackId
@@ -29,23 +29,23 @@
         if (!pool) {
             self->pool = [[NSMutableDictionary alloc] init];
         }
-        
+
         // Running in background to avoid thread locks
         [self.commandDelegate runInBackground:^{
-            
+
             CDVPluginResult* result = nil;
             Connection* socket = nil;
             NSString* key = nil;
             NSString* host = nil;
             int port = 0;
-            
+
             // Opening connection and adding into pool
             @try {
                 // Preparing parameters
                 host = [command.arguments objectAtIndex : 0];
                 port = [[command.arguments objectAtIndex : 1] integerValue];
                 key = [self buildKey : host : port];
-                
+
                 // Checking existing connections
                 if ([pool objectForKey : key]) {
                     NSLog(@"Recovered connection with %@", key);
@@ -59,10 +59,10 @@
                     socket = [[Connection alloc] initWithNetworkAddress:host :port];
                     [socket setDelegate:self];
                     [socket open];
-                    
+
                     // Adding to pool
                     [self->pool setObject:socket forKey:key];
-                    
+
                     // Formatting success response
                     result = [CDVPluginResult
                               resultWithStatus :
@@ -75,7 +75,7 @@
                           resultWithStatus : CDVCommandStatus_ERROR
                           messageAsString  : @"Unexpected exception when executing 'connect' action."];
             }
-            
+
             // Returns the Callback Resolution
             [self.commandDelegate sendPluginResult  : result
                                          callbackId : command.callbackId];
@@ -86,33 +86,33 @@
 - (void) isConnected : (CDVInvokedUrlCommand *) command {
     // Validating parameters
     if ([command.arguments count] < 1) {
-        
+
         // Triggering parameter error
         CDVPluginResult* result = [CDVPluginResult
                                    resultWithStatus : CDVCommandStatus_ERROR
                                    messageAsString  : @"Missing arguments when calling 'isConnected' action."];
-        
+
         [self.commandDelegate
             sendPluginResult:result
             callbackId:command.callbackId
          ];
-        
+
     } else {
-        
+
         // running in background to avoid thread locks
         [self.commandDelegate runInBackground : ^{
-            
+
             CDVPluginResult* result= nil;
             Connection* socket = nil;
             NSString* key = nil;
-            
+
             @try {
                 // Preparing parameters
                 key = [command.arguments objectAtIndex:0];
-                
+
                 // Getting connection from pool
                 socket = [pool objectForKey:key];
-                
+
                 // Checking if socket was not found and his conenctivity
                 if (socket == nil) {
                     NSLog(@"Connection not found");
@@ -121,7 +121,7 @@
                               messageAsString  : @"No connection found with host."];
                 } else {
                     NSLog(@"Checking data connection...");
-                    
+
                     // Formatting success response
                     result = [CDVPluginResult
                               resultWithStatus : CDVCommandStatus_OK
@@ -134,7 +134,7 @@
                           resultWithStatus : CDVCommandStatus_ERROR
                           messageAsString  : @"Unexpected exception when executon 'isConnected' action."];
             }
-            
+
             // Returning callback resolution
             [self.commandDelegate
                 sendPluginResult : result
@@ -147,24 +147,24 @@
 - (BOOL) disposeConnection : (NSString *) key {
     Connection* socket = nil;
     BOOL result = NO;
-    
+
     @try {
         // Getting connection from pool
         socket = [pool objectForKey : key];
-        
+
         // Closing connection
         if (socket) {
             [pool removeObjectForKey : key];
-            
+
             if ([socket isConnected])
                 [socket close];
-            
+
             socket = nil;
-            
+
             NSLog(@"Closed connection with %@", key);
         } else
            NSLog(@"Connection %@ already closed!", key);
-        
+
         // Setting success
         result = YES;
     }
@@ -184,15 +184,15 @@
         CDVPluginResult* result = [CDVPluginResult
                                    resultWithStatus : CDVCommandStatus_ERROR
                                    messageAsString  : @"Missing arguments when calling 'disconnect' action."];
-        
+
         [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
     } else {
         // Running in background to avoid thread locks
         [self.commandDelegate runInBackground : ^{
-            
+
             CDVPluginResult* result= nil;
             NSString *key = nil;
-            
+
             @try {
                 // Preparing parameters
                 key = [command.arguments objectAtIndex : 0];
@@ -211,7 +211,7 @@
                             resultWithStatus : CDVCommandStatus_ERROR
                             messageAsString  : @"Unexpected exception when executing 'disconnect' action."];
             }
-            
+
             // Returns the Callback Resolution
             [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
         }];
@@ -221,24 +221,24 @@
 - (void) disconnectAll: (CDVInvokedUrlCommand *) command {
     // Running in background to avoid thread locks
     [self.commandDelegate runInBackground:^{
-       
+
         CDVPluginResult* result = nil;
         Connection * socket = nil;
         BOOL partial = NO;
-        
+
         @try {
-            
+
             // Iterating connection pool
             for (id key in pool) {
                 socket = [pool objectForKey : key];
-                
+
                 // Try to close it
                 if (![self disposeConnection : key]) {
                     // If no success, need to set as partial disconnection
                     partial = YES;
                 }
             }
-            
+
             // Formatting result
             if (partial)
                 result = [CDVPluginResult
@@ -263,43 +263,43 @@
 }
 
 - (void) send: (CDVInvokedUrlCommand *) command {
-    
+
     // Validating parameters
     if ([command.arguments count] < 2) {
         // Triggering parameter error
         CDVPluginResult* result = [CDVPluginResult
                                    resultWithStatus : CDVCommandStatus_ERROR
                                    messageAsString  : @"Missing arguments when calling 'send' action."];
-        
+
         [self.commandDelegate
             sendPluginResult : result
             callbackId:command.callbackId
          ];
-        
+
     } else {
-        
+
         // Running in background to avoid thread locks
         [self.commandDelegate runInBackground : ^{
-            
+
             CDVPluginResult* result= nil;
             Connection* socket = nil;
             NSString* data = nil;
             NSString* key = nil;
-            
+
             @try {
                 // Preparing parameters
                 key = [command.arguments objectAtIndex : 0];
-                
+
                 // Getting connection from pool
                 socket = [pool objectForKey : key];
-                
+
                 // Checking if socket was not found and his conenctivity
                 if (socket == nil) {
                     NSLog(@"Connection not found");
                     result = [CDVPluginResult
                               resultWithStatus : CDVCommandStatus_ERROR
                               messageAsString  : @"No connection found with host."];
-                    
+
                 } else if (![socket isConnected]) {
                     NSLog(@"Socket is not connected.");
                     result = [CDVPluginResult
@@ -308,11 +308,11 @@
                 } else {
                     // Writting on output stream
                     data = [command.arguments objectAtIndex : 1];
-                    
+
                     NSLog(@"Sending data to %@ - %@", key, data);
-                    
+
                     [socket write:data];
-                
+
                     // Formatting success response
                     result = [CDVPluginResult
                               resultWithStatus : CDVCommandStatus_OK
@@ -325,26 +325,20 @@
                           resultWithStatus : CDVCommandStatus_ERROR
                           messageAsString  : @"Unexpected exception when executon 'send' action."];
             }
-            
+
             // Returning callback resolution
             [self.commandDelegate sendPluginResult : result callbackId : command.callbackId];
         }];
     }
 }
 
-- (void) sendMessage :(NSString *)host :(int)port :(NSString *)chunk {
-    
-    // Handling escape chars
-    NSMutableString *data = [NSMutableString stringWithString : chunk];
-    [data replaceOccurrencesOfString   : @"\n"
-                            withString : @"\\n"
-                            options    : NSCaseInsensitiveSearch
-                            range      : NSMakeRange(0, [data length])];
-    
+- (void) sendMessage :(NSString *)host :(int)port :(NSData *)chunk {
+    NSString *base64Encoded = [nsdata base64EncodedStringWithOptions:0];
+
     // Relay to webview
-    NSString *receiveHook = [NSString stringWithFormat : @"window.tlantic.plugins.socket.receive('%@', %d, '%@', '%@' );",
-                                host, port, [self buildKey : host : port], [NSString stringWithString : data]];
-    
+    NSString *receiveHook = [NSString stringWithFormat : @"window.tlantic.plugins.socket.receive('%@', %d, '%@', window.atob('%@') );",
+                                host, port, [self buildKey : host : port], base64Encoded];
+
     [self writeJavascript:receiveHook];
 }
 

--- a/src/ios/CDVSocketPlugin.m
+++ b/src/ios/CDVSocketPlugin.m
@@ -376,7 +376,7 @@
                                 resultWithStatus : CDVCommandStatus_ERROR
                                 messageAsString  : @"Invalid connection with host."];
                 } else {
-                    // Writting on output stream
+                    // Writing on output stream
                     data = [command.arguments objectAtIndex : 1];
 
                     NSMutableData *buf = [[NSMutableData alloc] init];

--- a/src/ios/CDVSocketPlugin.m
+++ b/src/ios/CDVSocketPlugin.m
@@ -333,7 +333,7 @@
 }
 
 - (void) sendMessage :(NSString *)host :(int)port :(NSData *)chunk {
-    NSString *base64Encoded = [nsdata base64EncodedStringWithOptions:0];
+    NSString *base64Encoded = [chunk base64EncodedStringWithOptions:0];
 
     // Relay to webview
     NSString *receiveHook = [NSString stringWithFormat : @"window.tlantic.plugins.socket.receive('%@', %d, '%@', window.atob('%@') );",

--- a/src/ios/CDVSocketPlugin.m
+++ b/src/ios/CDVSocketPlugin.m
@@ -415,7 +415,7 @@
     NSString *receiveHook = [NSString stringWithFormat : @"window.tlantic.plugins.socket.receive('%@', %d, '%@', window.atob('%@') );",
                                 host, port, [self buildKey : host : port], base64Encoded];
 
-    [self writeJavascript:receiveHook];
+    [self.commandDelegate evalJs : receiveHook];
 }
 
 @end

--- a/src/ios/CDVSocketPlugin.m
+++ b/src/ios/CDVSocketPlugin.m
@@ -156,8 +156,10 @@
         if (socket) {
             [pool removeObjectForKey : key];
 
-            if ([socket isConnected])
-                [socket close];
+            // Call close on the socket whether it's connected or not, to clean
+            // up the read/write streams and event handlers so we don't leak
+            // memory
+            [socket close];
 
             socket = nil;
 

--- a/src/ios/CDVSocketPlugin.m
+++ b/src/ios/CDVSocketPlugin.m
@@ -353,7 +353,7 @@
 
             CDVPluginResult* result= nil;
             Connection* socket = nil;
-            NSData* data = nil;
+            NSArray* data = nil;
             NSString* key = nil;
 
             @try {
@@ -363,7 +363,7 @@
                 // Getting connection from pool
                 socket = [pool objectForKey : key];
 
-                // Checking if socket was not found and his conenctivity
+                // Checking if socket was not found and his connectivity
                 if (socket == nil) {
                     NSLog(@"Connection not found");
                     result = [CDVPluginResult
@@ -379,14 +379,15 @@
                     // Writting on output stream
                     data = [command.arguments objectAtIndex : 1];
 
-                    /* void* buffer = malloc(512); */
-                    /* nsdata *shareddata = [[nsdata alloc] initwithbytesnocopy:buffer length:512 freewhendone:yes]; */
+                    NSMutableData *buf = [[NSMutableData alloc] init];
 
+                    for (int i = 0; i < [data count]; i++)
+                    {
+                        int byte = [data[i] intValue];
+                        [buf appendBytes : &byte length:1];
+                    }
 
-
-                    //NSLog(@"Sending data to %@ - %@", key, data);
-
-                    [socket writeBinary:data];
+                    [socket writeBinary:buf];
 
                     // Formatting success response
                     result = [CDVPluginResult

--- a/src/ios/Connection.h
+++ b/src/ios/Connection.h
@@ -21,6 +21,7 @@
 - (void) open;
 - (void) close;
 - (void) write : (NSString*) data;
+- (void) writeBinary : (NSData*) chunk;
 
 - (void) stream : (NSStream *) theStream handleEvent : (NSStreamEvent) streamEvent;
 

--- a/src/ios/Connection.h
+++ b/src/ios/Connection.h
@@ -1,6 +1,6 @@
 @protocol ConnectionDelegate <NSObject>
 
-- (void) sendMessage : (NSString *) host : (int)port : (NSString *) chunk;
+- (void) sendMessage : (NSString *) host : (int)port : (NSData *) line;
 
 @end
 

--- a/src/ios/Connection.m
+++ b/src/ios/Connection.m
@@ -74,12 +74,13 @@
         // Data receiving
         case NSStreamEventHasBytesAvailable:
             if (theStream == reader) {
-                /* uint8_t buffer[512]; */
                 void* buffer = malloc(512);
                 NSData *sharedData = [[NSData alloc] initWithBytesNoCopy:buffer length:512 freeWhenDone:YES];
                 NSInteger len;
 
                 while ([reader hasBytesAvailable]) {
+                    // This has a tendency to not fully read the packet,
+                    // requiring subsequent combination of values
                     len = [reader read : buffer maxLength : sizeof(buffer)];
 
                     NSData *line = [sharedData subdataWithRange:NSMakeRange(0, len)];

--- a/src/ios/Connection.m
+++ b/src/ios/Connection.m
@@ -87,7 +87,6 @@
                     if (len > 0) {
 
                         if (nil != line) {
-                            NSLog(@"Received data: %@", line);
                             [_hook sendMessage : _host : _port : line];
                         }
                     }

--- a/src/ios/Connection.m
+++ b/src/ios/Connection.m
@@ -74,17 +74,19 @@
         // Data receiving
         case NSStreamEventHasBytesAvailable:
             if (theStream == reader) {
-                uint8_t buffer[512];
+                /* uint8_t buffer[512]; */
+                void* buffer = malloc(512);
+                NSData *sharedData = [[NSData alloc] initWithBytesNoCopy:buffer length:512 freeWhenDone:YES];
                 NSInteger len;
 
                 while ([reader hasBytesAvailable]) {
                     len = [reader read : buffer maxLength : sizeof(buffer)];
 
-                    NSData *line = [buffer subdataWithRange:NSMakeRange(0, len)];
+                    NSData *line = [sharedData subdataWithRange:NSMakeRange(0, len)];
 
                     if (len > 0) {
 
-                        if (nil != chunk) {
+                        if (nil != line) {
                             NSLog(@"Received data: %@", line);
                             [_hook sendMessage : _host : _port : line];
                         }

--- a/src/ios/Connection.m
+++ b/src/ios/Connection.m
@@ -24,16 +24,16 @@
     // Init network communication settings
     CFReadStreamRef readStream;
     CFWriteStreamRef writeStream;
-    
+
     // Opening connection
     CFStreamCreatePairWithSocketToHost(NULL, (__bridge CFStringRef)_host, _port, &readStream, &writeStream);
-    
+
     // Configuring input stream
     reader = objc_retainedObject(readStream);
     [reader setDelegate:self];
     [reader scheduleInRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
     [reader open];
-    
+
     // Configuring output stream
     writer = objc_retainedObject(writeStream);
     [writer setDelegate:self];
@@ -47,7 +47,7 @@
     [writer removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
     [writer setDelegate:nil];
     writer = nil;
-    
+
     // Closing input stream
     [reader close];
     [reader removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
@@ -60,47 +60,49 @@
     [writer write : [chunk bytes] maxLength : [chunk length]];
 }
 
+- (void) writeBinary : (NSData *) chunk {
+    [writer write : [chunk bytes] maxLength : [chunk length]];
+}
+
 - (void) stream : (NSStream *) theStream handleEvent : (NSStreamEvent) streamEvent {
-	switch (streamEvent) {
-		case NSStreamEventOpenCompleted:
-			NSLog(@"Stream opened!");
+    switch (streamEvent) {
+        case NSStreamEventOpenCompleted:
+            NSLog(@"Stream opened!");
             connected = YES;
-			break;
-            
+            break;
+
         // Data receiving
-		case NSStreamEventHasBytesAvailable:
+        case NSStreamEventHasBytesAvailable:
             if (theStream == reader) {
-                uint8_t buffer[10240];
+                uint8_t buffer[512];
                 NSInteger len;
-                
+
                 while ([reader hasBytesAvailable]) {
                     len = [reader read : buffer maxLength : sizeof(buffer)];
-                    
+
+                    NSData *line = [buffer subdataWithRange:NSMakeRange(0, len)];
+
                     if (len > 0) {
-                        
-                        NSString *chunk = [[NSString alloc] initWithBytes : buffer
-                                                                   length : len
-                                                                 encoding : NSASCIIStringEncoding];
-                        
+
                         if (nil != chunk) {
-                            NSLog(@"Received data: %@", chunk);
-                            [_hook sendMessage : _host : _port : chunk];
+                            NSLog(@"Received data: %@", line);
+                            [_hook sendMessage : _host : _port : line];
                         }
                     }
                 }
             }
             break;
-            
+
         case NSStreamEventErrorOccurred:
             NSLog(@"Cannot connect to the host!");
             connected = NO;
             break;
-            
+
         case NSStreamEventEndEncountered:
             NSLog(@"Stream closed!");
             connected = NO;
             break;
-            
+
         default:
             NSLog(@"Unknown event!");
     }

--- a/www/socket.js
+++ b/www/socket.js
@@ -26,7 +26,7 @@ Socket.prototype.disconnectAll = function (successCallback, errorCallback) {
     'use strict';
     exec(successCallback, errorCallback, this.pluginRef, 'disconnectAll', []);
 };
-               
+
 //
 Socket.prototype.isConnected = function (connectionId, successCallback, errorCallback) {
     'use strict';
@@ -50,7 +50,7 @@ Socket.prototype.receive = function (host, port, connectionId, chunk) {
     'use strict';
 
     var evReceive = document.createEvent('Events');
-    
+
     evReceive.initEvent(this.receiveHookName, true, true);
     evReceive.metadata = {
         connection: {


### PR DESCRIPTION
This featureset does a couple of interesting things that may not be obvious:
1. Instead of always reading up to a null terminator (e.g. strings), this version reads until the input stream doesn't receive any packet data.
2. Instead of passing chunked, escaped strings back to Javascript, we base64-encode from the native later and then use `window.atob` on invocation of the Javascript to decode, ensuring we can pass true binary data back.

Be sure to view the pull request with `?w=1` appended to the URL (to ignore whitespace changes).
